### PR TITLE
Fix Telegram edit language detection

### DIFF
--- a/demo-server/server.go
+++ b/demo-server/server.go
@@ -939,9 +939,9 @@ func teleUpdateHandle(api, workdir string, comp compiler, timeout int, upd teleU
   )
   src, chat, msgId = teleGetSrc(upd);
   if upd.Msg.Txt == "" {
-    lang = upd.Msg.From.Lang
-  } else {
     lang = upd.Edited.From.Lang
+  } else {
+    lang = upd.Msg.From.Lang
   }
   lng = getMsgLangId(lang);
   output, err = handleInput("vostok", src, local(webHelp, lng) + local(teleHelp, lng),


### PR DESCRIPTION
## Summary
- fix inverted logic when choosing message language in Telegram handler

## Testing
- `go build server.go` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_6843052c8cb48333bac303e169de9cbb