### PR TITLE
Fix guarantee typo

### DIFF
--- a/documents/Language.md
+++ b/documents/Language.md
@@ -19,7 +19,7 @@ Implementation details missing from the report:
 
 ## Dynamic memory management
 
-Available 3 implementations that garantee data integrity and do not require additional assumptions
+Available 3 implementations that guarantee data integrity and do not require additional assumptions
 in the language:
 
  * Without freeing memory.


### PR DESCRIPTION
## Summary
- correct typo in the Language docs

## Testing
- `grep -n guarantee documents/Language.md`

------
https://chatgpt.com/codex/tasks/task_e_684337c476348333b5c24f1de448311a