### PR TITLE
fix(Int64): correct DivMod result handling

### DIFF
--- a/singularity/implementation.js/Int64.js
+++ b/singularity/implementation.js/Int64.js
@@ -112,10 +112,10 @@ function Mod(mod, n, d) {
 module.Mod = Mod;
 
 function DivMod(div, mod, n, d) {
-	n = tobig(n);
-	d = tobig(d);
-	frombig(div, n / d);
-	frombig(div, n % d);
+        n = tobig(n);
+        d = tobig(d);
+        frombig(div, n / d);
+        frombig(mod, n % d);
 }
 module.DivMod = DivMod;
 


### PR DESCRIPTION
## Summary
- fix incorrect modulo target in DivMod

## Testing
- `npm test` *(fails: bin/ost.js not found)*

------
https://chatgpt.com/codex/tasks/task_e_684337e925ec8333b3fec4d2e64bcfa9