### PR TITLE
Fix crash on SYSTEM.ADR constant

### DIFF
--- a/source/Ast.mod
+++ b/source/Ast.mod
@@ -3629,9 +3629,11 @@ VAR err, distance: INTEGER; fp: FormalParam; str: ExprString;
 				IF ~comp THEN
 					err := ErrCallAdrParamTypeWithPtr
 				END;
-				IF ~IsDesignateStableAddress(e(Designator)) THEN
-					INCL(c.ds.info, WithSystemAdrLocal)
-				END
+                                IF (e.id = IdDesignator)
+                                 & ~IsDesignateStableAddress(e(Designator))
+                                THEN
+                                        INCL(c.ds.info, WithSystemAdrLocal)
+                                END
 			ELSE
 				comp := FALSE
 			END


### PR DESCRIPTION
## Summary
- avoid invalid cast when validating arguments of SYSTEM.ADR

## Testing
- `result/bs-ost run 'make.Test; make.Self; make.SelfFull' -infr . -m source`
- `result/ost to-bin SystemAdrNoVar /tmp/out -m test/error -allow-system`

------
https://chatgpt.com/codex/tasks/task_e_6844623a6ccc83339d18acb7f11496da